### PR TITLE
Minor Edits/Fixes: Major Speed Improvements (m3u generation) / "Windows Support" / Output failed matches (m3u creation) / Fix navidrome.db directory

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -175,6 +175,7 @@ scripts/.cache
 *.db-wal
 navidrome.db*
 scripts/navidrome.db*
+data/navidrome.db*
 
 # Generated data files
 *.json

--- a/app.py
+++ b/app.py
@@ -56,7 +56,7 @@ SPOTIFY_REDIRECT_URI = os.getenv('REDIRECT_URI', 'http://localhost:8888/callback
 os.environ['REDIRECT_URI'] = SPOTIFY_REDIRECT_URI
 
 # Database configuration
-DATABASE_PATH = os.getenv('DATABASE_PATH', 'scripts/navidrome.db')
+DATABASE_PATH = os.getenv('DATABASE_PATH', 'navidrome.db')
 OUTPUT_DIR = os.getenv('OUTPUT_DIR', '.')
 DATA_DIR = os.getenv('DATA_DIR', 'data')
 
@@ -391,7 +391,7 @@ def generate_m3u():
             from spoti_playlist_to_m3u import generate_m3u_from_db
             
             socketio.emit('progress', {'message': 'Processing tracks with Navidrome database...', 'progress': 50})
-            generate_m3u_from_db(temp_file, output_file, test_mode=False)
+            generate_m3u_from_db(playlist_name, temp_file, output_file, test_mode=False)
             
             socketio.emit('progress', {'message': 'M3U playlist generated successfully!', 'progress': 100})
             socketio.emit('m3u_generated', {'file_path': output_file})

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,9 @@ services:
     volumes:
       # Mount external data directory for Navidrome database
       - ./data:/app/data
+      # - ./data/navidrome.db:/app/scripts/navidrome.db
       # Optional: Mount output directory for persistent storage
-      # - ./output:/app/output
+      - ./output:/app/output
     environment:
       - DATABASE_PATH=/app/data/navidrome.db
       - OUTPUT_DIR=/app/output

--- a/scripts/spoti_playlist_to_m3u.py
+++ b/scripts/spoti_playlist_to_m3u.py
@@ -4,7 +4,8 @@ import json
 import os
 
 # Path to your Navidrome SQLite database file
-DB_PATH = os.path.join(os.path.dirname(__file__), 'navidrome.db')
+DB_PATH = os.getenv('DATABASE_PATH', 'navidrome.db')
+OUTPUT_DIR = os.getenv('OUTPUT_DIR', '.')
 
 def navidrome_search_track_db(conn, track_name, artist_name):
     """Search Navidrome database for track by name and artist using SQL LIKE queries."""
@@ -91,7 +92,7 @@ def navidrome_search_track_db(conn, track_name, artist_name):
     
     return None
 
-def generate_m3u_from_db(spotify_playlist_json_path, output_path, test_mode=False):
+def generate_m3u_from_db(playlist_name, spotify_playlist_json_path, output_path, test_mode=False):
     """Generate M3U playlist from Spotify JSON using direct database access."""
     
     with open(spotify_playlist_json_path, 'r', encoding='utf-8') as f:
@@ -104,18 +105,21 @@ def generate_m3u_from_db(spotify_playlist_json_path, output_path, test_mode=Fals
     else:
         print(f"Processing {len(spotify_tracks)} tracks...")
     
-    lines = ['#EXTM3U', '#PLAYLIST:Spotify Imported Playlist']
+    lines = ['#EXTM3U', '#PLAYLIST:' + playlist_name]
     total_tracks = len(spotify_tracks)
     matched_count = 0
     processed_count = 0
     failed_matches = []
 
     # Simple progress indicator
-    print(f"Processing tracks...", end="", flush=True)
+    print(f"Processing tracks...", flush=True)
 
+    conn = None
     try:
         # Open database connection
+        print(f"Opening database: {DB_PATH}", flush=True)
         conn = sqlite3.connect(f'file:{DB_PATH}?mode=ro', uri=True)
+        print("Database connected successfully", flush=True)
         
         for i, track in enumerate(spotify_tracks):
             track_name = track['track_name']
@@ -151,17 +155,22 @@ def generate_m3u_from_db(spotify_playlist_json_path, output_path, test_mode=Fals
             # Simple progress indicator - print every few tracks
             if processed_count % 5 == 0 or processed_count == total_tracks:
                 percent = int((processed_count / total_tracks) * 100)
-                print(f"\r{percent}% ({processed_count}/{total_tracks}) - Matched: {matched_count}", end="", flush=True)
+                print(f"\r{percent}% ({processed_count}/{total_tracks}) - Matched: {matched_count}", flush=True)
 
     except sqlite3.Error as e:
-        print(f"\nSQLite error: {e}")
+        print(f"\nSQLite error: {e}", flush=True)
+        return
+    except Exception as e:
+        print(f"\n!!! Unexpected error: {e}", flush=True)
+        import traceback
+        traceback.print_exc()
         return
     finally:
-        if 'conn' in locals():
+        if conn:
             conn.close()
 
-    print(f"\nCompleted! Matched {matched_count} out of {total_tracks} tracks.")
-    print(f"Success rate: {(matched_count/total_tracks)*100:.1f}%")
+    print(f"\nCompleted! Matched {matched_count} out of {total_tracks} tracks.", flush=True)
+    print(f"Success rate: {(matched_count/total_tracks)*100:.1f}%", flush=True)
 
     # Write M3U file
     with open(output_path, 'w', encoding='utf-8') as f:
@@ -171,10 +180,21 @@ def generate_m3u_from_db(spotify_playlist_json_path, output_path, test_mode=Fals
     
     # Write failed matches to JSON file for analysis
     if failed_matches:
-        failed_file = output_path.replace('.m3u', '_failed_matches.json')
-        with open(failed_file, 'w', encoding='utf-8') as f:
-            json.dump(failed_matches, f, indent=2, ensure_ascii=False)
-        print(f"Failed matches written to: {failed_file}")
+        try:
+            print(f"\nWriting {len(failed_matches)} failed matches...", flush=True)
+            
+            base_name = os.path.splitext(os.path.basename(output_path))[0]
+            failed_file = os.path.join(OUTPUT_DIR, f"{base_name}_failed_matches.json")
+            
+            print(f"Failed matches file path: {failed_file}", flush=True)
+            
+            with open(failed_file, 'w', encoding='utf-8') as f:
+                json.dump(failed_matches, f, indent=2, ensure_ascii=False)
+            print(f"Failed matches written successfully to: {failed_file}", flush=True)
+        except Exception as e:
+            print(f"Error writing failed matches file: {e}", flush=True)
+            import traceback
+            traceback.print_exc()
 
 def list_songs(conn, limit=5):
     """Fetch and print song info from the database."""
@@ -217,15 +237,16 @@ def main():
                     
         elif command == 'generate':
             # Generate M3U playlist
-            spotify_json = sys.argv[2] if len(sys.argv) > 2 else 'playlist_tracks.json'
-            output_file = sys.argv[3] if len(sys.argv) > 3 else 'navidrome_playlist.m3u'
+            playlist_name = sys.argv[2] if len(sys.argv) > 2 else 'Spotify Playlist'
+            spotify_json = sys.argv[3] if len(sys.argv) > 3 else 'playlist_tracks.json'
+            output_file = sys.argv[4] if len(sys.argv) > 4 else 'navidrome_playlist.m3u'
             # test_mode = '--full' not in sys.argv
             
             if not os.path.exists(spotify_json):
                 print(f"Error: Spotify playlist JSON file not found: {spotify_json}")
                 return
                 
-            generate_m3u_from_db(spotify_json, output_file, test_mode=False)
+            generate_m3u_from_db(playlist_name, spotify_json, output_file, test_mode=False)
         else:
             print("Unknown command. Use 'list' or 'generate'")
     else:


### PR DESCRIPTION
Hey @ethanbarclay , thanks for putting together this script/app. Has been helpful in my pursuit to migrate my library from Spotify to my Navidrome instance.

Thought I'd share some of my edits to get this up and running on my windows machine (via docker), as well as some other QOL improvements:
- Load `navidrome.db` in-memory for super speedy `.m3u` playlist generation
- Playlist name set in `.m3u` file instead of using the hardcoded `"Spotify Imported Playlist"`
- correctly output  the `*_failed_matches.json` file for tracks not found in the Navidrome instance
- fix line endings on the `docker-entrypoint.sh` (windows line endings didn't play nice in docker)
- fix path for `navidrome.db` as document (`./data/navidrome.db` instead of `./scripts/navidrome.db`)

Speed improvements for in-memory db searching drastically speeds things up. Ran a 2k track playlist with a 40% hit rate in less than 10secs

Don't mind if you take these changes or not, just sharing my edits to help yourself and/or others that may stumble here.