### PR TITLE
Add embed fallback for Spotify-generated playlists, liked-songs count, and PORT config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,10 @@ CLIENT_ID=your_spotify_client_id_here
 CLIENT_SECRET=your_spotify_client_secret_here
 REDIRECT_URI=http://127.0.0.1:8888/callback
 
+# Server
+# Port to listen on (match the REDIRECT_URI port)
+PORT=8888
+
 # Navidrome
 DATABASE_PATH=/path/to/navidrome.db
 OUTPUT_DIR=./output

--- a/app.py
+++ b/app.py
@@ -391,9 +391,16 @@ def fetch_playlist():
                             "progress": 10,
                         },
                     ),
-                    on_progress=lambda count: socketio.emit(
+                    on_progress=lambda count, total: socketio.emit(
                         "progress",
-                        {"message": f"Fetched {count} tracks...", "progress": 50},
+                        {
+                            "message": f"Fetched {count} tracks...",
+                            "progress": (
+                                min(90, int((count / total) * 80) + 10)
+                                if total
+                                else 90
+                            ),
+                        },
                     ),
                 )
             else:
@@ -994,7 +1001,13 @@ def health_check():
 if __name__ == "__main__":
     # Check if we're in production environment
     is_production = os.getenv("FLASK_ENV") == "production"
-    port = int(os.getenv("PORT", "8888"))
+    try:
+        port = int(os.getenv("PORT", "8888"))
+    except ValueError:
+        print(
+            f"Invalid PORT value {os.getenv('PORT')!r}; falling back to 8888."
+        )
+        port = 8888
 
     if is_production:
         # Production mode - use allow_unsafe_werkzeug for simplicity

--- a/app.py
+++ b/app.py
@@ -946,13 +946,14 @@ def health_check():
 if __name__ == "__main__":
     # Check if we're in production environment
     is_production = os.getenv("FLASK_ENV") == "production"
+    port = int(os.getenv("PORT", "8888"))
 
     if is_production:
         # Production mode - use allow_unsafe_werkzeug for simplicity
         # In a real production environment, you'd want to use gunicorn or similar
         socketio.run(
-            app, debug=False, host="0.0.0.0", port=8888, allow_unsafe_werkzeug=True
+            app, debug=False, host="0.0.0.0", port=port, allow_unsafe_werkzeug=True
         )
     else:
         # Development mode
-        socketio.run(app, debug=True, host="0.0.0.0", port=8888)
+        socketio.run(app, debug=True, host="0.0.0.0", port=port)

--- a/app.py
+++ b/app.py
@@ -22,12 +22,16 @@ from flask import (
     url_for,
 )
 from flask_socketio import SocketIO, emit
+from spotipy.exceptions import SpotifyException
 from spotipy.oauth2 import SpotifyOAuth
 
 # Add scripts directory to path to import existing scripts
 sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), "scripts"))
 
-from spotify_client import flatten_track_item  # noqa: E402
+from spotify_client import (  # noqa: E402
+    fetch_playlist_via_embed,
+    flatten_track_item,
+)
 
 load_dotenv()
 
@@ -366,42 +370,73 @@ def fetch_playlist():
                 "progress", {"message": "Starting playlist fetch...", "progress": 0}
             )
 
-            # Get playlist info
-            playlist = sp.playlist(playlist_id)
-            socketio.emit(
-                "progress",
-                {
-                    "message": f'Fetching tracks from "{playlist["name"]}"...',
-                    "progress": 10,
-                },
-            )
+            # Get playlist info, falling back to the embed page for
+            # Spotify-owned algorithmic/editorial playlists (Daily Mix,
+            # Discover Weekly, etc.) which the Web API returns 404 for.
+            try:
+                playlist = sp.playlist(playlist_id)
+            except SpotifyException as e:
+                if e.http_status != 404:
+                    raise
+                playlist = None
 
-            # Fetch all tracks
-            tracks = []
-            limit = 100
-            offset = 0
-            total = playlist.get("tracks", {}).get("total", 1) or 1
-
-            while True:
-                results = sp.playlist_items(playlist_id, limit=limit, offset=offset)
-                items = results["items"]
-                if not items:
-                    break
-
-                for item in items:
-                    flat = flatten_track_item(item)
-                    if flat is None:
-                        continue
-                    tracks.append(flat)
-
-                offset += len(items)
-                progress = min(
-                    90, int((offset / total) * 80) + 10
+            if playlist is None:
+                playlist_name, tracks = fetch_playlist_via_embed(
+                    sp,
+                    playlist_id,
+                    on_name=lambda name: socketio.emit(
+                        "progress",
+                        {
+                            "message": f'Fetching tracks from "{name}"...',
+                            "progress": 10,
+                        },
+                    ),
+                    on_progress=lambda count: socketio.emit(
+                        "progress",
+                        {"message": f"Fetched {count} tracks...", "progress": 50},
+                    ),
                 )
+            else:
+                playlist_name = playlist["name"]
                 socketio.emit(
                     "progress",
-                    {"message": f"Fetched {offset} tracks...", "progress": progress},
+                    {
+                        "message": f'Fetching tracks from "{playlist_name}"...',
+                        "progress": 10,
+                    },
                 )
+
+                # Fetch all tracks
+                tracks = []
+                limit = 100
+                offset = 0
+                total = playlist.get("tracks", {}).get("total", 1) or 1
+
+                while True:
+                    results = sp.playlist_items(
+                        playlist_id, limit=limit, offset=offset
+                    )
+                    items = results["items"]
+                    if not items:
+                        break
+
+                    for item in items:
+                        flat = flatten_track_item(item)
+                        if flat is None:
+                            continue
+                        tracks.append(flat)
+
+                    offset += len(items)
+                    progress = min(
+                        90, int((offset / total) * 80) + 10
+                    )
+                    socketio.emit(
+                        "progress",
+                        {
+                            "message": f"Fetched {offset} tracks...",
+                            "progress": progress,
+                        },
+                    )
 
             # Save to temporary file
             temp_file = tempfile.NamedTemporaryFile(
@@ -420,7 +455,7 @@ def fetch_playlist():
             socketio.emit(
                 "playlist_fetched",
                 {
-                    "playlist_name": playlist["name"],
+                    "playlist_name": playlist_name,
                     "track_count": len(tracks),
                     "temp_file": temp_file.name,
                     "tracks": tracks,  # Send all tracks for pagination

--- a/app.py
+++ b/app.py
@@ -331,6 +331,19 @@ def get_user_playlists():
         return jsonify({"error": str(e)}), 500
 
 
+@app.route("/api/liked-songs-count")
+def get_liked_songs_count():
+    sp = get_spotify_client()
+    if not sp:
+        return jsonify({"error": "Not authenticated"}), 401
+
+    try:
+        results = sp.current_user_saved_tracks(limit=1, offset=0)
+        return jsonify({"total": results.get("total", 0)})
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
 @app.route("/api/fetch-playlist", methods=["POST"])
 def fetch_playlist():
     sp = get_spotify_client()

--- a/app.py
+++ b/app.py
@@ -27,6 +27,8 @@ from spotipy.oauth2 import SpotifyOAuth
 # Add scripts directory to path to import existing scripts
 sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), "scripts"))
 
+from spotify_client import flatten_track_item  # noqa: E402
+
 load_dotenv()
 
 app = Flask(__name__)
@@ -374,31 +376,10 @@ def fetch_playlist():
                     break
 
                 for item in items:
-                    track = item.get("item") or item.get("track")
-                    if track is None:
+                    flat = flatten_track_item(item)
+                    if flat is None:
                         continue
-                    if track.get("type") != "track":
-                        continue
-                    if not track.get("artists") or not track.get("album"):
-                        continue
-                    tracks.append(
-                        {
-                            "track_id": track["id"],
-                            "track_name": track["name"],
-                            "artist_name": ", ".join(
-                                [artist["name"] for artist in track["artists"]]
-                            ),
-                            "artist_id": ", ".join(
-                                [artist["id"] for artist in track["artists"]]
-                            ),
-                            "album_name": track["album"]["name"],
-                            "album_id": track["album"]["id"],
-                            "added_at": item.get("added_at", ""),
-                            "track_uri": track["uri"],
-                            "popularity": track.get("popularity", ""),
-                            "duration_ms": track.get("duration_ms", ""),
-                        }
-                    )
+                    tracks.append(flat)
 
                 offset += len(items)
                 progress = min(
@@ -478,27 +459,10 @@ def fetch_liked_songs():
                     break
 
                 for item in items:
-                    track = item.get("track")
-                    if track is None:
+                    flat = flatten_track_item(item)
+                    if flat is None:
                         continue
-                    tracks.append(
-                        {
-                            "track_id": track["id"],
-                            "track_name": track["name"],
-                            "artist_name": ", ".join(
-                                [artist["name"] for artist in track["artists"]]
-                            ),
-                            "artist_id": ", ".join(
-                                [artist["id"] for artist in track["artists"]]
-                            ),
-                            "album_name": track["album"]["name"],
-                            "album_id": track["album"]["id"],
-                            "added_at": item.get("added_at", ""),
-                            "track_uri": track["uri"],
-                            "popularity": track.get("popularity", ""),
-                            "duration_ms": track.get("duration_ms", ""),
-                        }
-                    )
+                    tracks.append(flat)
 
                 offset += len(items)
                 # Calculate accurate progress: 5% for initial setup, 90% for fetching, 5% for saving

--- a/scripts/fetch_spotify_liked.py
+++ b/scripts/fetch_spotify_liked.py
@@ -5,6 +5,8 @@ import json
 import os
 from dotenv import load_dotenv
 
+from spotify_client import flatten_track_item
+
 # Load environment variables from .env file
 load_dotenv()
 
@@ -32,21 +34,10 @@ while True:
     if not items:
         break
     for item in items:
-        track = item['track']
-        if track is None:  # skip removed tracks
+        flat = flatten_track_item(item)
+        if flat is None:
             continue
-        liked_tracks.append({
-            'track_id': track['id'],
-            'track_name': track['name'],
-            'artist_name': ', '.join([artist['name'] for artist in track['artists']]),
-            'artist_id': ', '.join([artist['id'] for artist in track['artists']]),
-            'album_name': track['album']['name'],
-            'album_id': track['album']['id'],
-            'added_at': item.get('added_at', ''),
-            'track_uri': track['uri'],
-            'popularity': track.get('popularity', ''),
-            'duration_ms': track.get('duration_ms', '')
-        })
+        liked_tracks.append(flat)
     offset += len(items)
     print(f"Fetched {offset} liked songs so far...")
 

--- a/scripts/spotify_client.py
+++ b/scripts/spotify_client.py
@@ -88,17 +88,29 @@ def fetch_embed_entity(playlist_id):
 
     Used as a fallback for Spotify-owned algorithmic/editorial playlists that
     the Web API blocks with a 404. Raises RuntimeError if the page can't be
-    parsed.
+    fetched or parsed.
     """
-    resp = requests.get(
-        EMBED_URL.format(playlist_id), headers=_EMBED_HEADERS, timeout=15
-    )
-    resp.raise_for_status()
+    try:
+        resp = requests.get(
+            EMBED_URL.format(playlist_id), headers=_EMBED_HEADERS, timeout=15
+        )
+        resp.raise_for_status()
+    except requests.RequestException as e:
+        # Keep error reporting predictable for this undocumented fallback path
+        # instead of leaking raw requests exceptions (404/429/network/etc.).
+        raise RuntimeError(f"Could not fetch Spotify embed page: {e}") from e
     match = _NEXT_DATA_RE.search(resp.text)
     if not match:
         raise RuntimeError("Could not parse Spotify embed page (no __NEXT_DATA__).")
-    data = json.loads(match.group(1))
-    return data["props"]["pageProps"]["state"]["data"]["entity"]
+    try:
+        data = json.loads(match.group(1))
+        return data["props"]["pageProps"]["state"]["data"]["entity"]
+    except (ValueError, KeyError, TypeError) as e:
+        # The embed page is undocumented; its JSON shape can change without
+        # notice. Surface a consistent error instead of a confusing traceback.
+        raise RuntimeError(
+            f"Could not parse Spotify embed page (unexpected structure): {e}"
+        ) from e
 
 
 def fetch_playlist_via_embed(sp, playlist_id, on_name=None, on_progress=None):
@@ -111,7 +123,8 @@ def fetch_playlist_via_embed(sp, playlist_id, on_name=None, on_progress=None):
     Args:
         on_name: optional callable(playlist_name), invoked once the name is
             known (before enrichment).
-        on_progress: optional callable(track_count), invoked after each batch.
+        on_progress: optional callable(track_count, total), invoked after each
+            batch so callers can render a progress bar.
 
     Returns:
         tuple: (playlist_name, tracks_list)
@@ -138,7 +151,7 @@ def fetch_playlist_via_embed(sp, playlist_id, on_name=None, on_progress=None):
             if flat is not None:
                 tracks.append(flat)
         if on_progress:
-            on_progress(len(tracks))
+            on_progress(len(tracks), len(track_ids))
 
     return playlist_name, tracks
 
@@ -157,8 +170,8 @@ def fetch_playlist_tracks(sp, playlist_id):
     except SpotifyException as e:
         if e.http_status == 404:
             print(
-                "Playlist not available via Web API (likely a Spotify-generated "
-                "playlist); using embed fallback..."
+                "Playlist not available via Web API (e.g. a Spotify-generated "
+                "playlist, or a private/invalid ID); trying embed fallback..."
             )
             name, tracks = fetch_playlist_via_embed(sp, playlist_id)
             print(f"Fetched {len(tracks)} playlist songs.")

--- a/scripts/spotify_client.py
+++ b/scripts/spotify_client.py
@@ -43,6 +43,34 @@ def extract_playlist_id(input_str):
     return input_str.strip()
 
 
+def flatten_track_item(item):
+    """Flatten a playlist or library item into our track dict, or None to skip.
+
+    Handles both the new ``item`` key and the deprecated ``track`` key returned
+    by Spotify's playlist endpoints, skips podcast episodes, and skips entries
+    missing required artist/album metadata.
+    """
+    track = item.get("item") or item.get("track")
+    if track is None:
+        return None
+    if track.get("type") != "track":
+        return None
+    if not track.get("artists") or not track.get("album"):
+        return None
+    return {
+        "track_id": track["id"],
+        "track_name": track["name"],
+        "artist_name": ", ".join(artist["name"] for artist in track["artists"]),
+        "artist_id": ", ".join(artist["id"] for artist in track["artists"]),
+        "album_name": track["album"]["name"],
+        "album_id": track["album"]["id"],
+        "added_at": item.get("added_at", ""),
+        "track_uri": track["uri"],
+        "popularity": track.get("popularity", ""),
+        "duration_ms": track.get("duration_ms", ""),
+    }
+
+
 def fetch_playlist_tracks(sp, playlist_id):
     """Fetch all tracks from a Spotify playlist with pagination.
 
@@ -63,27 +91,10 @@ def fetch_playlist_tracks(sp, playlist_id):
         if not items:
             break
         for item in items:
-            track = item.get("track")
-            if track is None:
+            flat = flatten_track_item(item)
+            if flat is None:
                 continue
-            tracks.append(
-                {
-                    "track_id": track["id"],
-                    "track_name": track["name"],
-                    "artist_name": ", ".join(
-                        [artist["name"] for artist in track["artists"]]
-                    ),
-                    "artist_id": ", ".join(
-                        [artist["id"] for artist in track["artists"]]
-                    ),
-                    "album_name": track["album"]["name"],
-                    "album_id": track["album"]["id"],
-                    "added_at": item.get("added_at", ""),
-                    "track_uri": track["uri"],
-                    "popularity": track.get("popularity", ""),
-                    "duration_ms": track.get("duration_ms", ""),
-                }
-            )
+            tracks.append(flat)
         offset += len(items)
         if offset % 200 == 0:
             print(f"Fetched {offset} playlist songs so far...")

--- a/scripts/spotify_client.py
+++ b/scripts/spotify_client.py
@@ -1,15 +1,27 @@
 """Shared Spotify client utilities for CLI scripts."""
 
+import json
 import os
 import re
 
+import requests
 import spotipy
 from dotenv import load_dotenv
+from spotipy.exceptions import SpotifyException
 from spotipy.oauth2 import SpotifyOAuth
 
 load_dotenv()
 
 SCOPE = "playlist-read-private playlist-read-collaborative"
+
+# Spotify-owned algorithmic/editorial playlists (Daily Mix, Discover Weekly,
+# Release Radar, the curated editorial lists, etc.) return 404 from the Web API
+# for third-party apps. The embed page below still exposes their track list.
+EMBED_URL = "https://open.spotify.com/embed/playlist/{}"
+_EMBED_HEADERS = {"User-Agent": "Mozilla/5.0"}
+_NEXT_DATA_RE = re.compile(
+    r'<script id="__NEXT_DATA__" type="application/json">(.*?)</script>', re.S
+)
 
 
 def get_spotify_client():
@@ -71,13 +83,87 @@ def flatten_track_item(item):
     }
 
 
-def fetch_playlist_tracks(sp, playlist_id):
-    """Fetch all tracks from a Spotify playlist with pagination.
+def fetch_embed_entity(playlist_id):
+    """Fetch a playlist's embed page and return its parsed entity dict.
+
+    Used as a fallback for Spotify-owned algorithmic/editorial playlists that
+    the Web API blocks with a 404. Raises RuntimeError if the page can't be
+    parsed.
+    """
+    resp = requests.get(
+        EMBED_URL.format(playlist_id), headers=_EMBED_HEADERS, timeout=15
+    )
+    resp.raise_for_status()
+    match = _NEXT_DATA_RE.search(resp.text)
+    if not match:
+        raise RuntimeError("Could not parse Spotify embed page (no __NEXT_DATA__).")
+    data = json.loads(match.group(1))
+    return data["props"]["pageProps"]["state"]["data"]["entity"]
+
+
+def fetch_playlist_via_embed(sp, playlist_id, on_name=None, on_progress=None):
+    """Fetch tracks for an editorial/algorithmic playlist via the embed page.
+
+    The embed page exposes track URIs even when the Web API returns 404. We
+    enrich those IDs through the public ``/tracks`` endpoint (which is not
+    blocked) so the resulting dicts match ``flatten_track_item`` exactly.
+
+    Args:
+        on_name: optional callable(playlist_name), invoked once the name is
+            known (before enrichment).
+        on_progress: optional callable(track_count), invoked after each batch.
 
     Returns:
         tuple: (playlist_name, tracks_list)
     """
-    playlist = sp.playlist(playlist_id, fields="name")
+    entity = fetch_embed_entity(playlist_id)
+    playlist_name = entity.get("name") or entity.get("title") or "Spotify Playlist"
+    track_list = entity.get("trackList") or []
+    if on_name:
+        on_name(playlist_name)
+
+    track_ids = []
+    for item in track_list:
+        uri = item.get("uri") or ""
+        if uri.startswith("spotify:track:"):
+            track_ids.append(uri.rsplit(":", 1)[-1])
+
+    tracks = []
+    for i in range(0, len(track_ids), 50):
+        batch = track_ids[i : i + 50]
+        for full_track in sp.tracks(batch)["tracks"]:
+            if full_track is None:
+                continue
+            flat = flatten_track_item({"track": full_track})
+            if flat is not None:
+                tracks.append(flat)
+        if on_progress:
+            on_progress(len(tracks))
+
+    return playlist_name, tracks
+
+
+def fetch_playlist_tracks(sp, playlist_id):
+    """Fetch all tracks from a Spotify playlist with pagination.
+
+    Falls back to the embed page for Spotify-owned algorithmic/editorial
+    playlists, which the Web API returns 404 for.
+
+    Returns:
+        tuple: (playlist_name, tracks_list)
+    """
+    try:
+        playlist = sp.playlist(playlist_id, fields="name")
+    except SpotifyException as e:
+        if e.http_status == 404:
+            print(
+                "Playlist not available via Web API (likely a Spotify-generated "
+                "playlist); using embed fallback..."
+            )
+            name, tracks = fetch_playlist_via_embed(sp, playlist_id)
+            print(f"Fetched {len(tracks)} playlist songs.")
+            return name, tracks
+        raise
     playlist_name = playlist["name"]
 
     tracks = []

--- a/static/js/liked_songs.js
+++ b/static/js/liked_songs.js
@@ -9,11 +9,31 @@ document.addEventListener('DOMContentLoaded', () => {
     const confirmSplitFinalBtn = document.getElementById('confirm-split-final');
     const splitSettingsDiv = document.getElementById('split-settings');
 
+    // Load the total liked-songs count on page mount
+    loadLikedSongsCount();
+
     // Handle fetch liked songs
     if (fetchLikedBtn) {
         fetchLikedBtn.addEventListener('click', async () => {
             await fetchLikedSongs();
         });
+    }
+
+    async function loadLikedSongsCount() {
+        const countDisplay = document.getElementById('liked-count-display');
+        const countValue = document.getElementById('liked-count-value');
+        if (!countDisplay || !countValue) return;
+
+        try {
+            const response = await window.spotifyApp.makeRequest('/api/liked-songs-count');
+            if (typeof response.total === 'number') {
+                countValue.textContent = response.total.toLocaleString();
+            } else {
+                countDisplay.style.display = 'none';
+            }
+        } catch (error) {
+            countDisplay.style.display = 'none';
+        }
     }
 
     // Handle JSON download

--- a/templates/liked_songs.html
+++ b/templates/liked_songs.html
@@ -23,6 +23,9 @@
             </div>
             <div class="card-body">
                 <p>Export all your liked songs from Spotify for processing and migration.</p>
+                <p class="small text-muted mb-3" id="liked-count-display">
+                    You have <strong id="liked-count-value">…</strong> liked songs in your library.
+                </p>
                 <button type="button" class="btn btn-danger" id="fetch-liked-songs">
                     <i class="fas fa-heart me-1"></i>Fetch All Liked Songs
                 </button>


### PR DESCRIPTION
## Summary

Bundles the work on `develop` since the last release to `main`:

- **Fetch Spotify-generated playlists** (Daily Mix, Discover Weekly, Release Radar, editorial lists). These return `404` from the Web API for third-party apps, so the tool previously errored on them. On a `404`, we now fall back to the public embed page (`open.spotify.com/embed/playlist/{id}`) to recover the track URIs, then enrich those IDs through the `/tracks` endpoint (which is not blocked). Output is byte-for-byte the same shape as a normal fetch (same 10 fields incl. album/artist IDs, popularity, duration); only `added_at` is blank, since editorial playlists carry no per-track timestamps. Works in **both** the CLI (`fetch_playlist_tracks`) and the web route, with **identical** progress messaging so the UI is indistinguishable from a normal fetch.
- **Liked-songs count** shown above the fetch button via a new `/api/liked-songs-count` endpoint.
- **Configurable server port** via a `PORT` env var (default `8888`), so the listen port can match the `REDIRECT_URI` independently of the public/proxy URL.
- **Refactor:** centralized Spotify item flattening into a shared `flatten_track_item` used by the web and CLI fetchers, removing duplicated logic.

## Commits

- `:recycle:` centralize spotify item flattening across web + CLI fetchers
- `:wrench:` make server port configurable via PORT env var
- `:sparkles:` show liked songs count above fetch button
- `:sparkles:` fetch spotify-generated playlists via embed fallback

## Notes

- The embed path is only ever used on a `404` from the official API; normal playlists are untouched and keep the official paginated fetch.
- The embed endpoint is undocumented/internal, so it could change; it's isolated behind `fetch_playlist_via_embed` and used strictly as a fallback.
- Spotify also filters its own editorial playlists out of `current_user_playlists` (verified: 0 returned), so hearted Daily Mixes still won't appear in the playlist list — they can only be fetched by pasting their URL.

## Testing

- CLI: `spoti_playlist_to_m3u.py generate --spotify <Daily Mix URL>` with a real OAuth token — 404 → embed fallback → fetched all 50 tracks.
- Function-level: editorial fetch returns 50 tracks with a key set identical to the normal flatten output; normal 5,627-track playlist still uses the official path unchanged.
- Web route messaging verified to emit the same `Fetching tracks from "…"` / `Fetched N tracks…` strings as a normal fetch.
- `pytest` green; imports/compile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)