### PR TITLE
Frontend cleanup: dedupe modal, shared action helpers, dep bumps

### DIFF
--- a/static/js/liked_songs.js
+++ b/static/js/liked_songs.js
@@ -39,8 +39,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // Handle JSON download
     if (downloadJsonBtn) {
         downloadJsonBtn.addEventListener('click', async () => {
-            if (!window.spotifyApp.currentTempFile) {
-                window.spotifyApp.showError('Please fetch your liked songs first');
+            if (!window.spotifyApp.requireTempFile('Please fetch your liked songs first')) {
                 return;
             }
 
@@ -51,8 +50,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // Handle M3U generation
     if (generateM3UBtn) {
         generateM3UBtn.addEventListener('click', async () => {
-            if (!window.spotifyApp.currentTempFile) {
-                window.spotifyApp.showError('Please fetch your liked songs first');
+            if (!window.spotifyApp.requireTempFile('Please fetch your liked songs first')) {
                 return;
             }
 
@@ -63,8 +61,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // Handle Lidarr submission
     if (sendToLidarrBtn) {
         sendToLidarrBtn.addEventListener('click', async () => {
-            if (!window.spotifyApp.currentTempFile) {
-                window.spotifyApp.showError('Please fetch your liked songs first');
+            if (!window.spotifyApp.requireTempFile('Please fetch your liked songs first')) {
                 return;
             }
 
@@ -75,8 +72,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // Handle split playlists button
     if (splitPlaylistsBtn) {
         splitPlaylistsBtn.addEventListener('click', () => {
-            if (!window.spotifyApp.currentTempFile) {
-                window.spotifyApp.showError('Please fetch your liked songs first');
+            if (!window.spotifyApp.requireTempFile('Please fetch your liked songs first')) {
                 return;
             }
 
@@ -102,59 +98,33 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
-    // Fetch liked songs
+    // Fetch liked songs (progress and results arrive via socket events)
     async function fetchLikedSongs() {
-        try {
-            window.spotifyApp.showProgress('Fetching Liked Songs');
-            
-            const response = await window.spotifyApp.makeRequest('/api/fetch-liked-songs', {
-                method: 'POST'
-            });
-
-            // Progress updates will be handled by socket events
-        } catch (error) {
-            window.spotifyApp.hideProgress();
-            window.spotifyApp.showError(`Failed to fetch liked songs: ${error.message}`);
-        }
+        await window.spotifyApp.runAction('/api/fetch-liked-songs', {
+            title: 'Fetching Liked Songs',
+            errorLabel: 'fetch liked songs'
+        });
     }
 
     // Generate M3U playlist
     async function generateM3U() {
-        try {
-            window.spotifyApp.showProgress('Generating M3U');
-            
-            const response = await window.spotifyApp.makeRequest('/api/generate-m3u', {
-                method: 'POST',
-                body: JSON.stringify({
-                    temp_file: window.spotifyApp.currentTempFile,
-                    playlist_name: 'liked_songs'
-                })
-            });
-
-            // Progress updates will be handled by socket events
-        } catch (error) {
-            window.spotifyApp.hideProgress();
-            window.spotifyApp.showError(`Failed to generate M3U: ${error.message}`);
-        }
+        await window.spotifyApp.runAction('/api/generate-m3u', {
+            title: 'Generating M3U',
+            body: {
+                temp_file: window.spotifyApp.currentTempFile,
+                playlist_name: 'liked_songs'
+            },
+            errorLabel: 'generate M3U'
+        });
     }
 
     // Send to Lidarr
     async function sendToLidarr() {
-        try {
-            window.spotifyApp.showProgress('Sending to Lidarr');
-            
-            const response = await window.spotifyApp.makeRequest('/api/send-to-lidarr', {
-                method: 'POST',
-                body: JSON.stringify({
-                    temp_file: window.spotifyApp.currentTempFile
-                })
-            });
-
-            // Progress updates will be handled by socket events
-        } catch (error) {
-            window.spotifyApp.hideProgress();
-            window.spotifyApp.showError(`Failed to send to Lidarr: ${error.message}`);
-        }
+        await window.spotifyApp.runAction('/api/send-to-lidarr', {
+            title: 'Sending to Lidarr',
+            body: { temp_file: window.spotifyApp.currentTempFile },
+            errorLabel: 'send to Lidarr'
+        });
     }
 
     // Show split confirmation modal
@@ -192,23 +162,15 @@ document.addEventListener('DOMContentLoaded', () => {
         const playlistSize = parseInt(document.getElementById('playlist-size').value);
         const playlistPrefix = document.getElementById('playlist-prefix').value.trim();
 
-        try {
-            window.spotifyApp.showProgress('Splitting Liked Songs');
-            
-            const response = await window.spotifyApp.makeRequest('/api/split-liked-songs', {
-                method: 'POST',
-                body: JSON.stringify({
-                    temp_file: window.spotifyApp.currentTempFile,
-                    playlist_size: playlistSize,
-                    playlist_prefix: playlistPrefix
-                })
-            });
-
-            // Progress updates will be handled by socket events
-        } catch (error) {
-            window.spotifyApp.hideProgress();
-            window.spotifyApp.showError(`Failed to split liked songs: ${error.message}`);
-        }
+        await window.spotifyApp.runAction('/api/split-liked-songs', {
+            title: 'Splitting Liked Songs',
+            body: {
+                temp_file: window.spotifyApp.currentTempFile,
+                playlist_size: playlistSize,
+                playlist_prefix: playlistPrefix
+            },
+            errorLabel: 'split liked songs'
+        });
     }
 
     // Download full JSON data

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -177,6 +177,30 @@ class SpotifyMigrationApp {
         }
     }
 
+    // Guard an action on a previously-fetched temp file; shows an error if missing.
+    requireTempFile(message = 'Please fetch data first') {
+        if (!this.currentTempFile) {
+            this.showError(message);
+            return false;
+        }
+        return true;
+    }
+
+    // Run a backend action: open the progress modal, POST, and surface errors.
+    // Progress and completion are delivered asynchronously via socket events.
+    async runAction(url, { title = 'Processing...', body = null, errorLabel = 'complete action' } = {}) {
+        try {
+            this.showProgress(title);
+            const options = { method: 'POST' };
+            if (body) options.body = JSON.stringify(body);
+            return await this.makeRequest(url, options);
+        } catch (error) {
+            this.hideProgress();
+            this.showError(`Failed to ${errorLabel}: ${error.message}`);
+            return null;
+        }
+    }
+
     // Playlist handling
     handlePlaylistFetched(data) {
         this.currentTempFile = data.temp_file;

--- a/static/js/playlists.js
+++ b/static/js/playlists.js
@@ -71,8 +71,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // Handle JSON download
     if (downloadJsonBtn) {
         downloadJsonBtn.addEventListener('click', async () => {
-            if (!window.spotifyApp.currentTempFile) {
-                window.spotifyApp.showError('Please fetch a playlist first');
+            if (!window.spotifyApp.requireTempFile('Please fetch a playlist first')) {
                 return;
             }
 
@@ -83,8 +82,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // Handle M3U generation
     if (generateM3UBtn) {
         generateM3UBtn.addEventListener('click', async () => {
-            if (!window.spotifyApp.currentTempFile) {
-                window.spotifyApp.showError('Please fetch a playlist first');
+            if (!window.spotifyApp.requireTempFile('Please fetch a playlist first')) {
                 return;
             }
 
@@ -95,8 +93,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // Handle MB Albums scan
     if (scanMBAlbumsBtn) {
         scanMBAlbumsBtn.addEventListener('click', async () => {
-            if (!window.spotifyApp.currentTempFile) {
-                window.spotifyApp.showError('Please fetch a playlist first');
+            if (!window.spotifyApp.requireTempFile('Please fetch a playlist first')) {
                 return;
             }
 
@@ -147,8 +144,8 @@ document.addEventListener('DOMContentLoaded', () => {
             <div class="playlist-item mb-2" data-playlist-id="${playlist.id}">
                 <div class="d-flex align-items-center">
                     <div class="flex-shrink-0">
-                        ${playlist.images && playlist.images[0] 
-                            ? `<img src="${playlist.images[0].url}" alt="${playlist.name}" 
+                        ${playlist.images && playlist.images[0]
+                            ? `<img src="${playlist.images[0].url}" alt="${window.spotifyApp.escapeHtml(playlist.name)}"
                                  class="rounded" style="width: 40px; height: 40px; object-fit: cover;">`
                             : `<div class="bg-secondary rounded d-flex align-items-center justify-content-center" 
                                  style="width: 40px; height: 40px;">
@@ -179,80 +176,46 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
-    // Fetch playlist data
+    // Fetch playlist data (progress and results arrive via socket events)
     async function fetchPlaylist(playlistId) {
-        try {
-            window.spotifyApp.showProgress('Fetching Playlist');
-            
-            const response = await window.spotifyApp.makeRequest('/api/fetch-playlist', {
-                method: 'POST',
-                body: JSON.stringify({ playlist_id: playlistId })
-            });
-
-            // Progress updates will be handled by socket events
-        } catch (error) {
-            window.spotifyApp.hideProgress();
-            window.spotifyApp.showError(`Failed to fetch playlist: ${error.message}`);
-        }
+        await window.spotifyApp.runAction('/api/fetch-playlist', {
+            title: 'Fetching Playlist',
+            body: { playlist_id: playlistId },
+            errorLabel: 'fetch playlist'
+        });
     }
 
     // Generate M3U playlist
     async function generateM3U() {
-        try {
-            window.spotifyApp.showProgress('Generating M3U');
-            
-            const response = await window.spotifyApp.makeRequest('/api/generate-m3u', {
-                method: 'POST',
-                body: JSON.stringify({
-                    temp_file: window.spotifyApp.currentTempFile,
-                    playlist_name: window.spotifyApp.currentPlaylistName || 'spotify_playlist'
-                })
-            });
-
-            // Progress updates will be handled by socket events
-        } catch (error) {
-            window.spotifyApp.hideProgress();
-            window.spotifyApp.showError(`Failed to generate M3U: ${error.message}`);
-        }
+        await window.spotifyApp.runAction('/api/generate-m3u', {
+            title: 'Generating M3U',
+            body: {
+                temp_file: window.spotifyApp.currentTempFile,
+                playlist_name: window.spotifyApp.currentPlaylistName || 'spotify_playlist'
+            },
+            errorLabel: 'generate M3U'
+        });
     }
 
     // Scan MusicBrainz albums
     async function scanMBAlbums() {
-        try {
-            window.spotifyApp.showProgress('Scanning MusicBrainz');
-
-            const response = await window.spotifyApp.makeRequest('/api/scan-mb-albums', {
-                method: 'POST',
-                body: JSON.stringify({
-                    temp_file: window.spotifyApp.currentTempFile,
-                    playlist_name: window.spotifyApp.currentPlaylistName || 'playlist'
-                })
-            });
-
-            // Progress updates will be handled by socket events
-        } catch (error) {
-            window.spotifyApp.hideProgress();
-            window.spotifyApp.showError(`Failed to scan MusicBrainz: ${error.message}`);
-        }
+        await window.spotifyApp.runAction('/api/scan-mb-albums', {
+            title: 'Scanning MusicBrainz',
+            body: {
+                temp_file: window.spotifyApp.currentTempFile,
+                playlist_name: window.spotifyApp.currentPlaylistName || 'playlist'
+            },
+            errorLabel: 'scan MusicBrainz'
+        });
     }
 
     // Send to Lidarr
     async function sendToLidarr() {
-        try {
-            window.spotifyApp.showProgress('Sending to Lidarr');
-
-            const response = await window.spotifyApp.makeRequest('/api/send-to-lidarr', {
-                method: 'POST',
-                body: JSON.stringify({
-                    mb_file: currentMBFile
-                })
-            });
-
-            // Progress updates will be handled by socket events
-        } catch (error) {
-            window.spotifyApp.hideProgress();
-            window.spotifyApp.showError(`Failed to send to Lidarr: ${error.message}`);
-        }
+        await window.spotifyApp.runAction('/api/send-to-lidarr', {
+            title: 'Sending to Lidarr',
+            body: { mb_file: currentMBFile },
+            errorLabel: 'send to Lidarr'
+        });
     }
 
     // Download full JSON data

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}Navidrome Import Tools{% endblock %}</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" rel="stylesheet">
     <link href="{{ url_for('static', filename='css/style.css') }}" rel="stylesheet">
 </head>
 <body>
@@ -138,8 +138,8 @@
         </div>
     </div>
 
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.0.1/socket.io.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.7.5/socket.io.min.js"></script>
     <script src="{{ url_for('static', filename='js/main.js') }}"></script>
     {% block scripts %}{% endblock %}
 </body>

--- a/templates/base.html
+++ b/templates/base.html
@@ -115,6 +115,29 @@
         </div>
     </div>
 
+    <!-- Success Modal -->
+    <div class="modal fade" id="successModal" tabindex="-1">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header bg-success text-white">
+                    <h5 class="modal-title">Success!</h5>
+                    <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body">
+                    <p id="success-message"></p>
+                    <div id="download-link" style="display: none;">
+                        <a href="#" class="btn btn-primary" id="download-btn">
+                            <i class="fas fa-download me-1"></i>Download File
+                        </a>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.0.1/socket.io.js"></script>
     <script src="{{ url_for('static', filename='js/main.js') }}"></script>

--- a/templates/liked_songs.html
+++ b/templates/liked_songs.html
@@ -184,29 +184,6 @@
         </div>
     </div>
 </div>
-
-<!-- Success Modal -->
-<div class="modal fade" id="successModal" tabindex="-1">
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header bg-success text-white">
-                <h5 class="modal-title">Success!</h5>
-                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
-            </div>
-            <div class="modal-body">
-                <p id="success-message"></p>
-                <div id="download-link" style="display: none;">
-                    <a href="#" class="btn btn-primary" id="download-btn">
-                        <i class="fas fa-download me-1"></i>Download File
-                    </a>
-                </div>
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-            </div>
-        </div>
-    </div>
-</div>
 {% endblock %}
 
 {% block scripts %}

--- a/templates/playlists.html
+++ b/templates/playlists.html
@@ -156,29 +156,6 @@
         </div>
     </div>
 </div>
-
-<!-- Success Modal -->
-<div class="modal fade" id="successModal" tabindex="-1">
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header bg-success text-white">
-                <h5 class="modal-title">Success!</h5>
-                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
-            </div>
-            <div class="modal-body">
-                <p id="success-message"></p>
-                <div id="download-link" style="display: none;">
-                    <a href="#" class="btn btn-primary" id="download-btn">
-                        <i class="fas fa-download me-1"></i>Download File
-                    </a>
-                </div>
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-            </div>
-        </div>
-    </div>
-</div>
 {% endblock %}
 
 {% block scripts %}


### PR DESCRIPTION
## Summary

Low-risk frontend cleanup — no behavior changes, net **−74 lines**.

- **Deduplicate the success modal.** It was copy-pasted into both `playlists.html` and `liked_songs.html` while `progress`/`error` modals already lived in `base.html`. Moved it into `base.html` (where `main.js`'s `showSuccess()` already expected a single shared modal) and removed both copies.
- **Share the fetch-action boilerplate.** Added `app.requireTempFile(msg)` and `app.runAction(url, {title, body, errorLabel})` to `main.js`, replacing the repeated *guard → showProgress → makeRequest → catch(hideProgress + showError)* pattern across `playlists.js` and `liked_songs.js` (~6 call sites each).
- **Escape an attribute.** The playlist-list `<img alt="...">` used the raw playlist name while the visible title was already escaped; now escaped consistently.
- **Bump pinned CDN deps:** Bootstrap `5.1.3 → 5.3.3`, Font Awesome `6.0.0 → 6.5.2`, socket.io client `4.0.1 → 4.7.5` (compatible with the Flask-SocketIO 5.3.6 server).

## Testing

- `node --check` passes on all three JS files.
- App runs; dashboard/settings/playlists/liked-songs all render `200` with no template errors.
- Verified the rendered HTML now contains exactly one `successModal`/`errorModal` (inherited from `base.html`) and the bumped asset versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)