### PR TITLE
Add "Send to Navidrome": create playlists via the Subsonic API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,8 +11,7 @@ PORT=8888
 DATABASE_PATH=/path/to/navidrome.db
 OUTPUT_DIR=./output
 
-# Navidrome server (Subsonic API) - for "Send to Navidrome" / send-navidrome
-# Base server URL (no /rest), and your Navidrome login
+# Navidrome server (for Send to Navidrome) - base URL (no /rest) + login
 NAVIDROME_URL=http://your_navidrome_server:4533
 NAVIDROME_USER=your_navidrome_username
 NAVIDROME_PASSWORD=your_navidrome_password

--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,12 @@ PORT=8888
 DATABASE_PATH=/path/to/navidrome.db
 OUTPUT_DIR=./output
 
+# Navidrome server (Subsonic API) - for "Send to Navidrome" / send-navidrome
+# Base server URL (no /rest), and your Navidrome login
+NAVIDROME_URL=http://your_navidrome_server:4533
+NAVIDROME_USER=your_navidrome_username
+NAVIDROME_PASSWORD=your_navidrome_password
+
 # Lidarr
 LIDARR_URL=http://your_lidarr_server:8686/api/v1
 API_KEY=your_lidarr_api_key_here

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Features an optional web interface with real-time progress tracking and playlist
 - **Playlist Management**: Fetch and export any Spotify playlist
 - **Liked Songs Export**: Export your entire liked songs collection
 - **M3U Generation**: Create playlist files compatible with Navidrome and other media players
+- **Send to Navidrome**: Create a playlist directly in Navidrome via the Subsonic API (no manual M3U import)
 - **Lidarr Integration**: Automatically add albums to your Lidarr instance
 - **Playlist Splitting**: Split large collections into manageable playlists
 - **Real-time Progress**: Live updates during processing via WebSocket
@@ -233,6 +234,9 @@ python scripts/spoti_playlist_to_m3u.py generate --json playlist_tracks.json "Pl
 
 # Use direct database queries instead of in-memory search (lower memory usage)
 python scripts/spoti_playlist_to_m3u.py generate --spotify "https://open.spotify.com/playlist/ID" output.m3u --no-memory
+
+# Create the playlist directly in Navidrome (Subsonic API) instead of an M3U file
+python scripts/spoti_playlist_to_m3u.py send-navidrome --spotify "https://open.spotify.com/playlist/ID" --name "My Playlist"
 ```
 
 `--spotify` and `--json` are mutually exclusive (one is required). When using `--spotify`, the playlist name is auto-fetched from the Spotify API. An optional `playlist_name` argument can override it.
@@ -240,6 +244,12 @@ python scripts/spoti_playlist_to_m3u.py generate --spotify "https://open.spotify
 **Requires:** `DATABASE_PATH`, `OUTPUT_DIR`. Additionally `CLIENT_ID`, `CLIENT_SECRET`, `REDIRECT_URI` when using `--spotify`.
 
 **Outputs:** `{name}.m3u` playlist file, `{name}_failed_matches.json` for unmatched tracks
+
+##### `send-navidrome` subcommand
+
+Matches tracks against `DATABASE_PATH` and creates the playlist in Navidrome via the Subsonic API — only tracks found in your library are added.
+
+**Requires:** `DATABASE_PATH` and `NAVIDROME_URL` / `NAVIDROME_USER` / `NAVIDROME_PASSWORD` (or the `--navidrome-url/-user/-password` flags). With `--json`, `--name` is required.
 
 #### `process_spotify_mb.py`
 

--- a/app.py
+++ b/app.py
@@ -29,6 +29,8 @@ from spotipy.oauth2 import SpotifyOAuth
 # Add scripts directory to path to import existing scripts
 sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), "scripts"))
 
+from navidrome_client import NavidromeClient, NavidromeError  # noqa: E402
+from spoti_playlist_to_m3u import collect_navidrome_song_ids  # noqa: E402
 from spotify_client import (  # noqa: E402
     fetch_playlist_via_embed,
     flatten_track_item,
@@ -92,6 +94,11 @@ os.environ["REDIRECT_URI"] = SPOTIFY_REDIRECT_URI
 DATABASE_PATH = os.getenv("DATABASE_PATH", "navidrome.db")
 OUTPUT_DIR = os.getenv("OUTPUT_DIR", ".")
 DATA_DIR = os.getenv("DATA_DIR", "data")
+
+# Navidrome server (Subsonic API) configuration for creating playlists
+NAVIDROME_URL = os.getenv("NAVIDROME_URL", "")
+NAVIDROME_USER = os.getenv("NAVIDROME_USER", "")
+NAVIDROME_PASSWORD = os.getenv("NAVIDROME_PASSWORD", "")
 
 # Settings file for runtime configuration
 SETTINGS_FILE = os.path.join(DATA_DIR, "settings.json")
@@ -284,6 +291,16 @@ def settings():
     )
 
 
+def get_navidrome_settings():
+    """Resolve Navidrome server settings from saved settings, falling back to env."""
+    nd = load_settings().get("navidrome", {})
+    return {
+        "url": nd.get("url") or NAVIDROME_URL,
+        "username": nd.get("username") or NAVIDROME_USER,
+        "password": nd.get("password") or NAVIDROME_PASSWORD,
+    }
+
+
 @app.route("/api/settings")
 def get_settings():
     """Get current settings"""
@@ -299,7 +316,8 @@ def get_settings():
                     "quality_profile_id": 1,
                     "metadata_profile_id": 1,
                 },
-            )
+            ),
+            "navidrome": get_navidrome_settings(),
         }
     )
 
@@ -320,6 +338,38 @@ def save_lidarr_settings():
     save_settings(saved_settings)
 
     return jsonify({"success": True, "message": "Lidarr settings saved"})
+
+
+@app.route("/api/settings/navidrome", methods=["POST"])
+def save_navidrome_settings():
+    """Save Navidrome server (Subsonic) settings"""
+    data = request.get_json()
+
+    saved_settings = load_settings()
+    saved_settings["navidrome"] = {
+        "url": data.get("url", ""),
+        "username": data.get("username", ""),
+        "password": data.get("password", ""),
+    }
+    save_settings(saved_settings)
+
+    return jsonify({"success": True, "message": "Navidrome settings saved"})
+
+
+@app.route("/api/test-navidrome-server", methods=["POST"])
+def test_navidrome_server():
+    """Test connectivity/credentials against the Navidrome server."""
+    data = request.get_json() or {}
+    # Use posted values if provided (test before saving), else saved/env settings.
+    url = data.get("url") or get_navidrome_settings()["url"]
+    username = data.get("username") or get_navidrome_settings()["username"]
+    password = data.get("password") or get_navidrome_settings()["password"]
+
+    try:
+        NavidromeClient(url, username, password).ping()
+        return jsonify({"success": True, "message": "Connected to Navidrome"})
+    except NavidromeError as e:
+        return jsonify({"success": False, "error": str(e)}), 400
 
 
 @app.route("/api/user-profile")
@@ -668,6 +718,97 @@ def generate_m3u():
     thread.start()
 
     return jsonify({"message": "M3U generation started"})
+
+
+@app.route("/api/send-to-navidrome", methods=["POST"])
+def send_to_navidrome():
+    data = request.get_json()
+    temp_file = data.get("temp_file")
+    playlist_name = data.get("playlist_name", "Spotify Playlist")
+
+    if not temp_file or not os.path.exists(temp_file):
+        return jsonify({"error": "Invalid temp file"}), 400
+
+    nd_settings = get_navidrome_settings()
+    if not all(nd_settings.values()):
+        return jsonify(
+            {"error": "Navidrome server is not configured. Add it in Settings."}
+        ), 400
+
+    room = session.get("session_id")
+
+    def notify(event, payload):
+        socketio.emit(event, payload, to=room)
+
+    def send_to_navidrome_task():
+        try:
+            if not os.path.exists(DATABASE_PATH):
+                notify(
+                    "error",
+                    {
+                        "message": f"Navidrome database not found at {DATABASE_PATH}. "
+                        "Please ensure your database is mounted correctly."
+                    },
+                )
+                return
+
+            notify(
+                "progress",
+                {"message": "Matching tracks against your library...", "progress": 10},
+            )
+            result = collect_navidrome_song_ids(temp_file, db_path=DATABASE_PATH)
+            song_ids = result["matched_ids"]
+
+            if not song_ids:
+                notify(
+                    "error",
+                    {
+                        "message": f"None of the {result['total']} tracks were found "
+                        "in your Navidrome library."
+                    },
+                )
+                return
+
+            notify(
+                "progress",
+                {
+                    "message": f"Creating playlist with {len(song_ids)} tracks...",
+                    "progress": 50,
+                },
+            )
+
+            client = NavidromeClient(
+                nd_settings["url"], nd_settings["username"], nd_settings["password"]
+            )
+
+            def on_progress(added, total):
+                pct = 50 + int((added / total) * 45) if total else 95
+                notify(
+                    "progress",
+                    {"message": f"Added {added} of {total} tracks...", "progress": pct},
+                )
+
+            client.create_playlist(playlist_name, song_ids, on_progress=on_progress)
+
+            notify(
+                "navidrome_complete",
+                {
+                    "playlist_name": playlist_name,
+                    "added": result["matched"],
+                    "total": result["total"],
+                    "skipped": result["total"] - result["matched"],
+                },
+            )
+
+        except NavidromeError as e:
+            notify("error", {"message": f"Navidrome error: {str(e)}"})
+        except Exception as e:
+            notify("error", {"message": f"Error sending to Navidrome: {str(e)}"})
+
+    thread = threading.Thread(target=send_to_navidrome_task)
+    thread.start()
+
+    return jsonify({"message": "Send to Navidrome started"})
 
 
 @app.route("/api/scan-mb-albums", methods=["POST"])

--- a/scripts/navidrome_client.py
+++ b/scripts/navidrome_client.py
@@ -1,0 +1,117 @@
+"""Subsonic API client for creating playlists in Navidrome.
+
+Authenticates with the standard Subsonic salt+token scheme
+(``t = md5(password + salt)``) and creates playlists via ``createPlaylist`` /
+``updatePlaylist``. Large playlists are added in chunks so the request never
+grows unbounded.
+"""
+
+import hashlib
+import secrets
+
+import requests
+
+API_VERSION = "1.16.1"
+CLIENT_NAME = "navidrome-import-tools"
+# Max song ids per request. Liked-songs collections can be thousands of tracks;
+# chunking keeps each POST body a sane size (and well under any URL limits).
+ADD_CHUNK = 200
+
+
+class NavidromeError(RuntimeError):
+    """Raised when the Navidrome/Subsonic API returns an error or is unreachable."""
+
+
+class NavidromeClient:
+    def __init__(self, base_url, username, password, client_name=CLIENT_NAME):
+        if not base_url or not username or not password:
+            raise NavidromeError(
+                "Navidrome URL, username and password are all required."
+            )
+        # Expect the server root (e.g. http://host:4533); tolerate a trailing
+        # slash or an accidental /rest suffix.
+        base = base_url.rstrip("/")
+        if base.endswith("/rest"):
+            base = base[: -len("/rest")]
+        self.base_url = base
+        self.username = username
+        self._password = password
+        self.client_name = client_name
+
+    def _auth_params(self):
+        salt = secrets.token_hex(8)
+        token = hashlib.md5((self._password + salt).encode("utf-8")).hexdigest()
+        return [
+            ("u", self.username),
+            ("t", token),
+            ("s", salt),
+            ("v", API_VERSION),
+            ("c", self.client_name),
+            ("f", "json"),
+        ]
+
+    def _post(self, endpoint, extra_params):
+        url = f"{self.base_url}/rest/{endpoint}"
+        data = self._auth_params() + list(extra_params)
+        try:
+            resp = requests.post(url, data=data, timeout=30)
+            resp.raise_for_status()
+        except requests.RequestException as e:
+            raise NavidromeError(f"Request to {endpoint} failed: {e}") from e
+
+        try:
+            payload = resp.json()["subsonic-response"]
+        except (ValueError, KeyError) as e:
+            raise NavidromeError(
+                f"Unexpected response from {endpoint}: {e}"
+            ) from e
+
+        if payload.get("status") != "ok":
+            err = payload.get("error", {})
+            raise NavidromeError(
+                f"Navidrome error {err.get('code', '?')}: "
+                f"{err.get('message', 'unknown error')}"
+            )
+        return payload
+
+    def ping(self):
+        """Verify connectivity and credentials. Raises NavidromeError on failure."""
+        self._post("ping", [])
+        return True
+
+    def create_playlist(self, name, song_ids, on_progress=None):
+        """Create a playlist named ``name`` containing ``song_ids``.
+
+        The playlist is created with the first chunk of songs; any remaining
+        songs are appended via ``updatePlaylist`` in further chunks. ``on_progress``
+        (if given) is called as ``on_progress(added, total)`` after each chunk.
+
+        Returns the new playlist id.
+        """
+        if not song_ids:
+            raise NavidromeError("No songs to add to the playlist.")
+
+        total = len(song_ids)
+        first, rest = song_ids[:ADD_CHUNK], song_ids[ADD_CHUNK:]
+
+        params = [("name", name)] + [("songId", sid) for sid in first]
+        payload = self._post("createPlaylist", params)
+        playlist_id = payload.get("playlist", {}).get("id")
+        if not playlist_id:
+            raise NavidromeError("createPlaylist did not return a playlist id.")
+
+        added = len(first)
+        if on_progress:
+            on_progress(added, total)
+
+        for i in range(0, len(rest), ADD_CHUNK):
+            batch = rest[i : i + ADD_CHUNK]
+            params = [("playlistId", playlist_id)] + [
+                ("songIdToAdd", sid) for sid in batch
+            ]
+            self._post("updatePlaylist", params)
+            added += len(batch)
+            if on_progress:
+                on_progress(added, total)
+
+        return playlist_id

--- a/scripts/spoti_playlist_to_m3u.py
+++ b/scripts/spoti_playlist_to_m3u.py
@@ -338,6 +338,49 @@ def generate_m3u_from_db(
             traceback.print_exc()
 
 
+def collect_navidrome_song_ids(spotify_playlist_json_path, db_path=DB_PATH):
+    """Match Spotify tracks against the Navidrome library and collect song ids.
+
+    Reuses the same in-memory matcher as M3U generation, but returns the
+    matched ``media_file.id`` values (which are also the Subsonic song ids)
+    instead of writing an M3U.
+
+    Returns:
+        dict: {"matched_ids": [...], "matched": int, "total": int,
+               "failed": [{"track_name", "artist_name"}, ...]}
+    """
+    with open(spotify_playlist_json_path, "r", encoding="utf-8") as f:
+        spotify_tracks = json.load(f)
+
+    total = len(spotify_tracks)
+    matched_ids = []
+    failed = []
+
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro&immutable=1", uri=True)
+    try:
+        library = NavidromeLibrary(conn)
+        for track in spotify_tracks:
+            song = library.search_track(track["track_name"], track["artist_name"])
+            if song and song.get("id"):
+                matched_ids.append(song["id"])
+            else:
+                failed.append(
+                    {
+                        "track_name": track["track_name"],
+                        "artist_name": track["artist_name"],
+                    }
+                )
+    finally:
+        conn.close()
+
+    return {
+        "matched_ids": matched_ids,
+        "matched": len(matched_ids),
+        "total": total,
+        "failed": failed,
+    }
+
+
 def list_songs(conn, limit=5):
     """Fetch and print song info from the database."""
     cursor = conn.execute(
@@ -400,6 +443,33 @@ def main():
         "--no-memory",
         action="store_true",
         help="Use direct database queries instead of in-memory search",
+    )
+
+    # send-navidrome command
+    nd_parser = subparsers.add_parser(
+        "send-navidrome",
+        help="Create a playlist in Navidrome (Subsonic API) from Spotify data",
+    )
+    nd_source = nd_parser.add_mutually_exclusive_group(required=True)
+    nd_source.add_argument(
+        "--spotify",
+        metavar="URL_OR_ID",
+        help="Fetch tracks directly from a Spotify playlist URL or ID",
+    )
+    nd_source.add_argument(
+        "--json",
+        metavar="FILE",
+        help="Use a pre-fetched JSON file of playlist tracks",
+    )
+    nd_parser.add_argument(
+        "--name",
+        default=None,
+        help="Playlist name (required with --json, auto-fetched with --spotify)",
+    )
+    nd_parser.add_argument("--navidrome-url", default=os.getenv("NAVIDROME_URL", ""))
+    nd_parser.add_argument("--navidrome-user", default=os.getenv("NAVIDROME_USER", ""))
+    nd_parser.add_argument(
+        "--navidrome-password", default=os.getenv("NAVIDROME_PASSWORD", "")
     )
 
     args = parser.parse_args()
@@ -468,6 +538,75 @@ def main():
         # Clean up temp file if we created one
         if args.spotify:
             os.unlink(spotify_json)
+
+    elif args.command == "send-navidrome":
+        from navidrome_client import NavidromeClient, NavidromeError
+
+        # Resolve tracks JSON + playlist name (same source handling as generate)
+        if args.spotify:
+            from spotify_client import (
+                extract_playlist_id,
+                fetch_playlist_tracks,
+                get_spotify_client,
+            )
+
+            sp = get_spotify_client()
+            playlist_id = extract_playlist_id(args.spotify)
+            playlist_name, tracks = fetch_playlist_tracks(sp, playlist_id)
+            if args.name:
+                playlist_name = args.name
+
+            tmp = tempfile.NamedTemporaryFile(
+                mode="w", suffix=".json", delete=False, encoding="utf-8"
+            )
+            json.dump(tracks, tmp, ensure_ascii=False, indent=2)
+            tmp.close()
+            spotify_json = tmp.name
+        else:
+            spotify_json = args.json
+            playlist_name = args.name
+            if not playlist_name:
+                print("Error: --name is required when using --json")
+                sys.exit(1)
+            if not os.path.exists(spotify_json):
+                print(f"Error: Spotify playlist JSON file not found: {spotify_json}")
+                return
+
+        try:
+            result = collect_navidrome_song_ids(spotify_json)
+            if not result["matched_ids"]:
+                print(
+                    f"No matches: none of the {result['total']} tracks were found "
+                    "in your Navidrome library."
+                )
+                return
+
+            print(
+                f"Matched {result['matched']} of {result['total']} tracks. "
+                "Creating playlist..."
+            )
+            client = NavidromeClient(
+                args.navidrome_url, args.navidrome_user, args.navidrome_password
+            )
+            playlist_id = client.create_playlist(
+                playlist_name,
+                result["matched_ids"],
+                on_progress=lambda a, t: print(f"  added {a}/{t}", flush=True),
+            )
+
+            skipped = result["total"] - result["matched"]
+            summary = (
+                f"Created playlist '{playlist_name}' (id {playlist_id}): "
+                f"added {result['matched']} of {result['total']} tracks"
+            )
+            summary += f", {skipped} not in library." if skipped else "."
+            print(summary)
+        except NavidromeError as e:
+            print(f"Navidrome error: {e}")
+            sys.exit(1)
+        finally:
+            if args.spotify and os.path.exists(spotify_json):
+                os.unlink(spotify_json)
 
 
 if __name__ == "__main__":

--- a/static/js/liked_songs.js
+++ b/static/js/liked_songs.js
@@ -3,6 +3,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const fetchLikedBtn = document.getElementById('fetch-liked-songs');
     const downloadJsonBtn = document.getElementById('download-json-liked');
     const generateM3UBtn = document.getElementById('generate-m3u-liked');
+    const sendToNavidromeBtn = document.getElementById('send-to-navidrome-liked');
     const sendToLidarrBtn = document.getElementById('send-to-lidarr-liked');
     const splitPlaylistsBtn = document.getElementById('split-playlists');
     const confirmSplitBtn = document.getElementById('confirm-split');
@@ -55,6 +56,17 @@ document.addEventListener('DOMContentLoaded', () => {
             }
 
             await generateM3U();
+        });
+    }
+
+    // Handle Send to Navidrome
+    if (sendToNavidromeBtn) {
+        sendToNavidromeBtn.addEventListener('click', async () => {
+            if (!window.spotifyApp.requireTempFile('Please fetch your liked songs first')) {
+                return;
+            }
+
+            await sendToNavidrome();
         });
     }
 
@@ -115,6 +127,18 @@ document.addEventListener('DOMContentLoaded', () => {
                 playlist_name: 'liked_songs'
             },
             errorLabel: 'generate M3U'
+        });
+    }
+
+    // Send liked songs to Navidrome as a new playlist
+    async function sendToNavidrome() {
+        await window.spotifyApp.runAction('/api/send-to-navidrome', {
+            title: 'Sending to Navidrome',
+            body: {
+                temp_file: window.spotifyApp.currentTempFile,
+                playlist_name: 'Liked Songs'
+            },
+            errorLabel: 'send to Navidrome'
         });
     }
 

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -49,6 +49,11 @@ class SpotifyMigrationApp {
             this.hideProgress();
             this.handleLidarrComplete(data);
         });
+
+        this.socket.on('navidrome_complete', (data) => {
+            this.hideProgress();
+            this.handleNavidromeComplete(data);
+        });
     }
 
     bindEvents() {
@@ -373,6 +378,16 @@ class SpotifyMigrationApp {
     // Lidarr completion handling
     handleLidarrComplete(data) {
         this.showSuccess(data.message);
+    }
+
+    // Navidrome playlist completion handling
+    handleNavidromeComplete(data) {
+        const name = data.playlist_name || 'playlist';
+        let message = `Created playlist "${name}" in Navidrome — added ${data.added} of ${data.total} tracks.`;
+        if (data.skipped > 0) {
+            message += ` ${data.skipped} not in your library.`;
+        }
+        this.showSuccess(message);
     }
 
     // Download JSON function

--- a/static/js/playlists.js
+++ b/static/js/playlists.js
@@ -4,6 +4,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const playlistInput = document.getElementById('playlist-input');
     const downloadJsonBtn = document.getElementById('download-json');
     const generateM3UBtn = document.getElementById('generate-m3u');
+    const sendToNavidromeBtn = document.getElementById('send-to-navidrome');
     const scanMBAlbumsBtn = document.getElementById('scan-mb-albums');
     const sendToLidarrBtn = document.getElementById('send-to-lidarr');
     const userPlaylistsDiv = document.getElementById('user-playlists');
@@ -87,6 +88,17 @@ document.addEventListener('DOMContentLoaded', () => {
             }
 
             await generateM3U();
+        });
+    }
+
+    // Handle Send to Navidrome
+    if (sendToNavidromeBtn) {
+        sendToNavidromeBtn.addEventListener('click', async () => {
+            if (!window.spotifyApp.requireTempFile('Please fetch a playlist first')) {
+                return;
+            }
+
+            await sendToNavidrome();
         });
     }
 
@@ -194,6 +206,18 @@ document.addEventListener('DOMContentLoaded', () => {
                 playlist_name: window.spotifyApp.currentPlaylistName || 'spotify_playlist'
             },
             errorLabel: 'generate M3U'
+        });
+    }
+
+    // Send playlist to Navidrome as a new playlist
+    async function sendToNavidrome() {
+        await window.spotifyApp.runAction('/api/send-to-navidrome', {
+            title: 'Sending to Navidrome',
+            body: {
+                temp_file: window.spotifyApp.currentTempFile,
+                playlist_name: window.spotifyApp.currentPlaylistName || 'Spotify Playlist'
+            },
+            errorLabel: 'send to Navidrome'
         });
     }
 

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -147,9 +147,30 @@ document.addEventListener('DOMContentLoaded', () => {
                 document.getElementById('navidrome-url').value = nd.url || '';
                 document.getElementById('navidrome-username').value = nd.username || '';
                 document.getElementById('navidrome-password').value = nd.password || '';
+
+                // Auto-check API status (like the DB status) if configured
+                if (nd.url && nd.username && nd.password) {
+                    checkNavidromeApiStatus();
+                }
             }
         } catch (error) {
             console.error('Failed to load settings:', error);
+        }
+    }
+
+    // Background check of the Navidrome API connection for the status badge
+    async function checkNavidromeApiStatus() {
+        updateStatusBadge('navidrome-api-status', 'secondary', 'Checking...');
+        try {
+            await window.spotifyApp.makeRequest('/api/test-navidrome-server', {
+                method: 'POST',
+                body: JSON.stringify({})
+            });
+            updateStatusBadge('navidrome-api-status', 'success', 'Connected');
+            updateStatusBadge('navidrome-server-status', 'success', 'Connected');
+        } catch (error) {
+            updateStatusBadge('navidrome-api-status', 'danger', 'Failed');
+            updateStatusBadge('navidrome-server-status', 'danger', 'Failed');
         }
     }
 
@@ -190,10 +211,12 @@ document.addEventListener('DOMContentLoaded', () => {
                 body: JSON.stringify(settings)
             });
             updateStatusBadge('navidrome-server-status', 'success', 'Connected');
+            updateStatusBadge('navidrome-api-status', 'success', 'Connected');
             showTestResult('Navidrome Server Test', 'success',
                 response.message || 'Successfully connected to Navidrome!', null);
         } catch (error) {
             updateStatusBadge('navidrome-server-status', 'danger', 'Failed');
+            updateStatusBadge('navidrome-api-status', 'danger', 'Failed');
             showTestResult('Navidrome Server Test', 'danger',
                 `Connection failed: ${error.message}`, null);
         } finally {

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -3,6 +3,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const lidarrForm = document.getElementById('lidarr-settings');
     const testLidarrBtn = document.getElementById('test-lidarr');
     const testNavidromeBtn = document.getElementById('test-navidrome');
+    const navidromeForm = document.getElementById('navidrome-settings');
+    const testNavidromeServerBtn = document.getElementById('test-navidrome-server');
 
     // Handle Lidarr settings form
     if (lidarrForm) {
@@ -23,6 +25,21 @@ document.addEventListener('DOMContentLoaded', () => {
     if (testNavidromeBtn) {
         testNavidromeBtn.addEventListener('click', async () => {
             await testNavidromeDatabase();
+        });
+    }
+
+    // Handle Navidrome server settings form
+    if (navidromeForm) {
+        navidromeForm.addEventListener('submit', async (e) => {
+            e.preventDefault();
+            await saveNavidromeSettings();
+        });
+    }
+
+    // Handle Navidrome server connection test
+    if (testNavidromeServerBtn) {
+        testNavidromeServerBtn.addEventListener('click', async () => {
+            await testNavidromeServer();
         });
     }
 
@@ -123,8 +140,65 @@ document.addEventListener('DOMContentLoaded', () => {
                 document.getElementById('quality-profile').value = lidarr.quality_profile_id || 1;
                 document.getElementById('metadata-profile').value = lidarr.metadata_profile_id || 1;
             }
+
+            // Populate Navidrome server settings
+            if (response.navidrome) {
+                const nd = response.navidrome;
+                document.getElementById('navidrome-url').value = nd.url || '';
+                document.getElementById('navidrome-username').value = nd.username || '';
+                document.getElementById('navidrome-password').value = nd.password || '';
+            }
         } catch (error) {
             console.error('Failed to load settings:', error);
+        }
+    }
+
+    // Save Navidrome server settings
+    async function saveNavidromeSettings() {
+        const settings = {
+            url: document.getElementById('navidrome-url').value.trim(),
+            username: document.getElementById('navidrome-username').value.trim(),
+            password: document.getElementById('navidrome-password').value,
+        };
+
+        try {
+            const response = await window.spotifyApp.makeRequest('/api/settings/navidrome', {
+                method: 'POST',
+                body: JSON.stringify(settings)
+            });
+            window.spotifyApp.showSuccess(response.message || 'Navidrome settings saved');
+        } catch (error) {
+            window.spotifyApp.showError(`Failed to save Navidrome settings: ${error.message}`);
+        }
+    }
+
+    // Test Navidrome server connection
+    async function testNavidromeServer() {
+        const settings = {
+            url: document.getElementById('navidrome-url').value.trim(),
+            username: document.getElementById('navidrome-username').value.trim(),
+            password: document.getElementById('navidrome-password').value,
+        };
+
+        const originalText = testNavidromeServerBtn.innerHTML;
+        testNavidromeServerBtn.innerHTML = '<i class="fas fa-spinner fa-spin me-1"></i>Testing...';
+        testNavidromeServerBtn.disabled = true;
+
+        try {
+            const response = await window.spotifyApp.makeRequest('/api/test-navidrome-server', {
+                method: 'POST',
+                body: JSON.stringify(settings)
+            });
+            updateStatusBadge('navidrome-server-status', 'success', 'Connected');
+            showTestResult('Navidrome Server Test', 'success',
+                response.message || 'Successfully connected to Navidrome!', null);
+        } catch (error) {
+            updateStatusBadge('navidrome-server-status', 'danger', 'Failed');
+            showTestResult('Navidrome Server Test', 'danger',
+                `Connection failed: ${error.message}`, null);
+        } finally {
+            testNavidromeServerBtn.innerHTML = originalText;
+            testNavidromeServerBtn.disabled = false;
         }
     }
 

--- a/templates/liked_songs.html
+++ b/templates/liked_songs.html
@@ -51,6 +51,9 @@
                         <button type="button" class="btn btn-outline-primary" id="generate-m3u-liked">
                             <i class="fas fa-file-audio me-1"></i>Generate M3U
                         </button>
+                        <button type="button" class="btn btn-outline-success" id="send-to-navidrome-liked">
+                            <i class="fas fa-list-music me-1"></i>Send to Navidrome
+                        </button>
                         <button type="button" class="btn btn-outline-success" id="send-to-lidarr-liked">
                             <i class="fas fa-server me-1"></i>Send to Lidarr
                         </button>

--- a/templates/playlists.html
+++ b/templates/playlists.html
@@ -57,6 +57,9 @@
                         <button type="button" class="btn btn-outline-primary" id="generate-m3u">
                             <i class="fas fa-file-audio me-1"></i>Generate M3U
                         </button>
+                        <button type="button" class="btn btn-outline-success" id="send-to-navidrome">
+                            <i class="fas fa-list-music me-1"></i>Send to Navidrome
+                        </button>
                         <div class="btn-group" role="group">
                             <button type="button" class="btn btn-outline-info" id="scan-mb-albums">
                                 <i class="fas fa-compact-disc me-1"></i>Scan MB Albums

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -156,6 +156,45 @@
                 </button>
             </div>
         </div>
+
+        <div class="card mt-4">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <h5 class="mb-0">
+                    <i class="fas fa-list-music text-success me-2"></i>
+                    Navidrome Server (Playlists)
+                </h5>
+                <span id="navidrome-server-status" class="badge bg-secondary">Unknown</span>
+            </div>
+            <div class="card-body">
+                <p class="text-muted small">
+                    Used by "Send to Navidrome" to create playlists via the Subsonic API.
+                </p>
+                <form id="navidrome-settings">
+                    <div class="mb-3">
+                        <label for="navidrome-url" class="form-label">Server URL</label>
+                        <input type="url" class="form-control" id="navidrome-url"
+                               placeholder="http://your-navidrome:4533">
+                        <div class="form-text">Base URL of your Navidrome server (no /rest)</div>
+                    </div>
+                    <div class="mb-3">
+                        <label for="navidrome-username" class="form-label">Username</label>
+                        <input type="text" class="form-control" id="navidrome-username"
+                               placeholder="Your Navidrome username">
+                    </div>
+                    <div class="mb-3">
+                        <label for="navidrome-password" class="form-label">Password</label>
+                        <input type="password" class="form-control" id="navidrome-password"
+                               placeholder="Your Navidrome password">
+                    </div>
+                    <button type="button" class="btn btn-success" id="test-navidrome-server">
+                        <i class="fas fa-plug me-1"></i>Test Connection
+                    </button>
+                    <button type="submit" class="btn btn-primary">
+                        <i class="fas fa-save me-1"></i>Save Settings
+                    </button>
+                </form>
+            </div>
+        </div>
     </div>
 
     <div class="col-md-4">

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -161,7 +161,7 @@
             <div class="card-header d-flex justify-content-between align-items-center">
                 <h5 class="mb-0">
                     <i class="fas fa-list-music text-success me-2"></i>
-                    Navidrome Server (Playlists)
+                    Navidrome Server
                 </h5>
                 <span id="navidrome-server-status" class="badge bg-secondary">Unknown</span>
             </div>
@@ -255,6 +255,11 @@
                     {% else %}
                         <span class="badge bg-danger" id="navidrome-status">Not Found</span>
                     {% endif %}
+                </div>
+
+                <div class="mb-2">
+                    <strong>Navidrome API:</strong>
+                    <span class="badge bg-secondary" id="navidrome-api-status">Not Tested</span>
                 </div>
             </div>
         </div>

--- a/tests/test_navidrome.py
+++ b/tests/test_navidrome.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Offline tests for the Navidrome send-to-playlist feature."""
+
+import hashlib
+import json
+import os
+import sqlite3
+import sys
+
+import pytest
+
+sys.path.insert(
+    0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts")
+)
+
+import navidrome_client
+from navidrome_client import NavidromeClient, NavidromeError
+from spoti_playlist_to_m3u import collect_navidrome_song_ids
+
+
+# --------------------------------------------------------------------------- #
+# collect_navidrome_song_ids: match against a synthetic Navidrome library DB
+# --------------------------------------------------------------------------- #
+def _make_db(path):
+    conn = sqlite3.connect(path)
+    conn.execute(
+        "CREATE TABLE media_file (id, path, title, artist, album_artist, album, duration)"
+    )
+    conn.executemany(
+        "INSERT INTO media_file VALUES (?, ?, ?, ?, ?, ?, ?)",
+        [
+            ("id1", "a/coordinate.mp3", "Coordinate", "Young Dolph", "Young Dolph", "Dum and Dummer 2", 198),
+            ("id2", "b/die_trying.mp3", "Die Trying", "Key Glock", "Key Glock", "PRE5L", 153),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_collect_matches_and_misses(tmp_path):
+    db = tmp_path / "navidrome.db"
+    _make_db(str(db))
+
+    tracks = [
+        {"track_name": "Coordinate", "artist_name": "Young Dolph"},     # matches id1
+        {"track_name": "Die Trying", "artist_name": "Key Glock"},       # matches id2
+        {"track_name": "Not In Library", "artist_name": "Nobody"},      # miss
+    ]
+    spotify_json = tmp_path / "tracks.json"
+    spotify_json.write_text(json.dumps(tracks), encoding="utf-8")
+
+    result = collect_navidrome_song_ids(str(spotify_json), db_path=str(db))
+
+    assert result["matched_ids"] == ["id1", "id2"]
+    assert result["matched"] == 2
+    assert result["total"] == 3
+    assert len(result["failed"]) == 1
+    assert result["failed"][0]["track_name"] == "Not In Library"
+
+
+# --------------------------------------------------------------------------- #
+# NavidromeClient: auth params + chunked create_playlist + error handling
+# --------------------------------------------------------------------------- #
+class _FakeResp:
+    def __init__(self, payload, status=200):
+        self._payload = payload
+        self.status_code = status
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._payload
+
+
+@pytest.fixture
+def captured_posts(monkeypatch):
+    calls = []
+
+    def fake_post(url, data=None, timeout=None):
+        calls.append({"url": url, "data": list(data)})
+        if url.endswith("/rest/createPlaylist"):
+            payload = {"subsonic-response": {"status": "ok", "playlist": {"id": "PL123"}}}
+        else:  # ping, updatePlaylist
+            payload = {"subsonic-response": {"status": "ok"}}
+        return _FakeResp(payload)
+
+    monkeypatch.setattr(navidrome_client.requests, "post", fake_post)
+    return calls
+
+
+def test_auth_params_use_salt_token(captured_posts):
+    client = NavidromeClient("http://nd:4533", "ethan", "secret")
+    client.ping()
+
+    data = dict(captured_posts[0]["data"])
+    assert data["u"] == "ethan"
+    assert data["f"] == "json"
+    # token must be md5(password + salt)
+    assert data["t"] == hashlib.md5(("secret" + data["s"]).encode()).hexdigest()
+    assert captured_posts[0]["url"] == "http://nd:4533/rest/ping"
+
+
+def test_create_playlist_chunks(captured_posts):
+    client = NavidromeClient("http://nd:4533/", "ethan", "secret")
+    song_ids = [f"s{i}" for i in range(450)]  # 200 + 200 + 50 -> create + 2 updates
+    progress = []
+
+    pid = client.create_playlist("My List", song_ids, on_progress=lambda a, t: progress.append((a, t)))
+
+    assert pid == "PL123"
+    endpoints = [c["url"].rsplit("/", 1)[-1] for c in captured_posts]
+    assert endpoints == ["createPlaylist", "updatePlaylist", "updatePlaylist"]
+
+    # first request: name + 200 songId
+    first = captured_posts[0]["data"]
+    assert ("name", "My List") in first
+    assert sum(1 for k, _ in first if k == "songId") == 200
+    # remaining added via songIdToAdd
+    assert sum(1 for k, _ in captured_posts[1]["data"] if k == "songIdToAdd") == 200
+    assert sum(1 for k, _ in captured_posts[2]["data"] if k == "songIdToAdd") == 50
+    assert progress == [(200, 450), (400, 450), (450, 450)]
+
+
+def test_create_playlist_empty_raises(captured_posts):
+    client = NavidromeClient("http://nd:4533", "ethan", "secret")
+    with pytest.raises(NavidromeError):
+        client.create_playlist("Empty", [])
+
+
+def test_subsonic_error_raises(monkeypatch):
+    def fake_post(url, data=None, timeout=None):
+        return _FakeResp(
+            {"subsonic-response": {"status": "failed", "error": {"code": 40, "message": "Wrong username or password"}}}
+        )
+
+    monkeypatch.setattr(navidrome_client.requests, "post", fake_post)
+    client = NavidromeClient("http://nd:4533", "ethan", "bad")
+    with pytest.raises(NavidromeError) as exc:
+        client.ping()
+    assert "Wrong username or password" in str(exc.value)
+
+
+def test_base_url_strips_rest_suffix():
+    client = NavidromeClient("http://nd:4533/rest/", "ethan", "secret")
+    assert client.base_url == "http://nd:4533"
+
+
+def test_missing_credentials_raises():
+    with pytest.raises(NavidromeError):
+        NavidromeClient("http://nd:4533", "", "secret")


### PR DESCRIPTION
## Summary

Adds a one-click **"Send to Navidrome"** that creates a real playlist in Navidrome via the **Subsonic API** (salt+token auth, like `navidrome-radio`), instead of only producing an M3U file for manual import. Available on both the **Playlists** and **Liked Songs** pages, plus a new **CLI subcommand**.

The enabling insight: the existing library matcher (`NavidromeLibrary.search_track`) already returns `media_file.id`, which *is* the Subsonic song id — so this is a thin API client over the matching that already happens for M3U generation.

## What's included

- **`scripts/navidrome_client.py`** — `NavidromeClient`: salt+token auth (`t=md5(password+salt)`), `ping()`, and `create_playlist(name, song_ids, on_progress)`. Songs are added in **chunks** (createPlaylist + updatePlaylist) so large liked-songs collections don't overflow request limits.
- **`scripts/spoti_playlist_to_m3u.py`** — `collect_navidrome_song_ids()` reuses the existing matcher to gather matched ids; new **`send-navidrome`** CLI subcommand (mirrors `generate`: `--spotify`/`--json`, `--name`, creds from env or flags).
- **`app.py`** — Navidrome server settings (`/api/settings` + `/api/settings/navidrome`), a `/api/test-navidrome-server` connection test, and `/api/send-to-navidrome` with per-room socket progress + a `navidrome_complete` event.
- **Frontend** — a "Navidrome Server (Playlists)" settings card (URL/user/password + Test Connection) and "Send to Navidrome" buttons on both fetch pages, reusing the shared `requireTempFile`/`runAction` helpers.
- **Docs/env** — `NAVIDROME_URL/USER/PASSWORD` in `.env.example`; README feature + CLI notes.

Only tracks matched in the local library are added; the UI/CLI report "added N of M (K not in library)" — same inherent limitation as M3U today.

## Testing

- **Automated (no live infra):** `tests/test_navidrome.py` — `collect_navidrome_song_ids` against a synthetic sqlite `media_file` DB (matches/misses); `NavidromeClient` with mocked HTTP (salt+token correctness, chunked create→update batching, Subsonic-error handling). Full suite: **9 passed**.
- `py_compile`, `node --check` on all changed JS, and direct template renders confirm the new card + buttons.

## Notes
- Navidrome password is stored in `settings.json`, consistent with how the Lidarr API key is already stored (plaintext, server-side).
- **Not yet tested against a live Navidrome server** — the end-to-end path (configure server → Test Connection → Send to Navidrome) needs a real instance + `navidrome.db`.
- Out of scope: updating/replacing an existing same-named playlist (always creates new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)